### PR TITLE
Test fix

### DIFF
--- a/src/App.Metrics.DotNetRuntime.Tests/StatsCollectors/IntegrationTests/ContentionStatsCollectorTests.cs
+++ b/src/App.Metrics.DotNetRuntime.Tests/StatsCollectors/IntegrationTests/ContentionStatsCollectorTests.cs
@@ -58,8 +58,7 @@ namespace AppMetrics.DotNetRuntime.Tests.StatsCollectors.IntegrationTests
                 {
                     lock (key)
                     {
-                        Task.Delay(TimeSpan.FromMilliseconds(sleepForMs)).GetAwaiter().GetResult();
-                        //Thread.Sleep(TimeSpan.FromMilliseconds(sleepForMs));
+                        Thread.Sleep(TimeSpan.FromMilliseconds(sleepForMs));
                     }        
                 }));
             

--- a/src/App.Metrics.DotNetRuntime.Tests/StatsCollectors/IntegrationTests/ContentionStatsCollectorTests.cs
+++ b/src/App.Metrics.DotNetRuntime.Tests/StatsCollectors/IntegrationTests/ContentionStatsCollectorTests.cs
@@ -49,7 +49,7 @@ namespace AppMetrics.DotNetRuntime.Tests.StatsCollectors.IntegrationTests
 
             // arrange
             const int numThreads = 10;
-            const int sleepForMs = 50;
+            const int sleepForMs = 100;
             var key = new object();
             
             // Increase the min. thread pool size so that when we use Thread.Sleep, we don't run into scheduling delays

--- a/src/App.Metrics.DotNetRuntime.Tests/StatsCollectors/IntegrationTests/ContentionStatsCollectorTests.cs
+++ b/src/App.Metrics.DotNetRuntime.Tests/StatsCollectors/IntegrationTests/ContentionStatsCollectorTests.cs
@@ -42,39 +42,48 @@ namespace AppMetrics.DotNetRuntime.Tests.StatsCollectors.IntegrationTests
         /// <returns></returns>
         [Test]
         [Repeat(5)]
-        public async Task Will_measure_contention_on_a_contested_lock()
+        public void Will_measure_contention_on_a_contested_lock()
         {
-            MetricsClient.Provider.Timer.Instance(DotNetRuntimeMetricsRegistry.Timers.ContentionMilliSecondsTotal).Reset();
+            var timer = MetricsClient.Provider.Timer.Instance(DotNetRuntimeMetricsRegistry.Timers.ContentionMilliSecondsTotal);
+            timer.Reset();
+
             // arrange
             const int numThreads = 10;
             const int sleepForMs = 50;
             var key = new object();
+            
             // Increase the min. thread pool size so that when we use Thread.Sleep, we don't run into scheduling delays
             ThreadPool.SetMinThreads(numThreads * 2, 1);
 
             // act
-            var tasks = Enumerable.Range(1, numThreads)
-                .Select(_ => Task.Run(() =>
+            var waitHandles = new WaitHandle[numThreads];
+            for (var i = 0; i < numThreads; i++)
+            {
+                var handle = new EventWaitHandle(false, EventResetMode.ManualReset);
+                var thread = new Thread(() =>
                 {
                     lock (key)
                     {
-                        Thread.Sleep(TimeSpan.FromMilliseconds(sleepForMs));
-                    }        
-                }));
-            
-            await Task.WhenAll(tasks);
+                        Thread.Sleep(sleepForMs);
+                    }
+
+                    handle.Set();
+                });
+                waitHandles[i] = handle;
+                thread.Start();
+            }
+            WaitHandle.WaitAll(waitHandles);
 
             // assert
             // Why -1? The first thread will not contend the lock 
             const int numLocksContended = numThreads - 1;
-            Assert.That( MetricsClient.Provider.Timer.Instance(DotNetRuntimeMetricsRegistry.Timers.ContentionMilliSecondsTotal).GetValueOrDefault().Rate.Count, 
-                Is.GreaterThanOrEqualTo(numLocksContended));
-            
+            Assert.That(timer.GetValueOrDefault().Rate.Count, Is.GreaterThanOrEqualTo(numLocksContended));
+
             // Pattern of expected contention times is: 50ms, 100ms, 150ms, etc.
             var expectedDelay = TimeSpan.FromMilliseconds(Enumerable.Range(1, numLocksContended).Aggregate(sleepForMs, (acc, next) => acc + (sleepForMs * next)));
-            var actualValueInNanoSeconds = MetricsClient.Provider.Timer.Instance(DotNetRuntimeMetricsRegistry.Timers.ContentionMilliSecondsTotal).GetValueOrDefault().Histogram.Sum;
-            Assert.That(actualValueInNanoSeconds, Is.EqualTo(expectedDelay.Ticks * 100).Within((sleepForMs + 5) * 1000000)); 
-            
+            var actualValue = TimeSpan.FromMilliseconds(timer.GetValueOrDefault().Histogram.Sum / 1000D / 1000D);
+            var within = TimeSpan.FromMilliseconds((sleepForMs + sleepForMs * 0.1D));
+            Assert.That(actualValue, Is.EqualTo(expectedDelay).Within(within));
         }
     }
 }

--- a/src/App.Metrics.DotNetRuntime.Tests/StatsCollectors/IntegrationTests/ThreadPoolStatsCollectorTests.cs
+++ b/src/App.Metrics.DotNetRuntime.Tests/StatsCollectors/IntegrationTests/ThreadPoolStatsCollectorTests.cs
@@ -32,7 +32,7 @@ namespace AppMetrics.DotNetRuntime.Tests.StatsCollectors.IntegrationTests
             Assert.That(() => GetGauage(DotNetRuntimeMetricsRegistry.Gauges.NumThreads.Name).Value, 
                 Is.GreaterThanOrEqualTo(Environment.ProcessorCount).After(2000, 10));
             Assert.That(() => GetMeter(DotNetRuntimeMetricsRegistry.Meters.AdjustmentsTotal.Name, "reason:climbing_move").Value.Count,
-                Is.GreaterThanOrEqualTo(1).After(2100, 10));
+                Is.GreaterThanOrEqualTo(1).After(2000 + (int) (2000 * 0.1D), 10));
         }
         
         [Test]

--- a/src/App.Metrics.DotNetRuntime.Tests/StatsCollectors/IntegrationTests/ThreadPoolStatsCollectorTests.cs
+++ b/src/App.Metrics.DotNetRuntime.Tests/StatsCollectors/IntegrationTests/ThreadPoolStatsCollectorTests.cs
@@ -32,7 +32,7 @@ namespace AppMetrics.DotNetRuntime.Tests.StatsCollectors.IntegrationTests
             Assert.That(() => GetGauage(DotNetRuntimeMetricsRegistry.Gauges.NumThreads.Name).Value, 
                 Is.GreaterThanOrEqualTo(Environment.ProcessorCount).After(2000, 10));
             Assert.That(() => GetMeter(DotNetRuntimeMetricsRegistry.Meters.AdjustmentsTotal.Name, "reason:climbing_move").Value.Count,
-                Is.GreaterThanOrEqualTo(1).After(2000, 10));
+                Is.GreaterThanOrEqualTo(1).After(2100, 10));
         }
         
         [Test]


### PR DESCRIPTION
* Thread.Sleep should give us the same blocking behavior as Task.Delay().GetAwaiter().GetResult()
* Give some additional time for event processing, 10%. It's not working consistently else.